### PR TITLE
Confirm Exit, Map Settings Fixes

### DIFF
--- a/Chkdraft/Source Files/Chkdraft.cpp
+++ b/Chkdraft/Source Files/Chkdraft.cpp
@@ -1,7 +1,7 @@
 #include "Chkdraft.h"
 
 void Chkdraft::OnLoadTest()
-{///*
+{/*
 	// Standard Map Open
 	maps.NewMap(128, 128, 0, 0, 0);
 	maps.FocusActive();

--- a/Chkdraft/Source Files/Forces.h
+++ b/Chkdraft/Source Files/Forces.h
@@ -9,12 +9,13 @@ class ForcesWindow : public ClassWindow
 	public:
 		ForcesWindow();
 		bool CreateThis(HWND hParent);
+		bool DestroyThis();
 
 	private:
 		LRESULT WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 		void CheckReplaceForceName(int force);
 
-		UINT WM_DRAGNOTIFY;
+		bool possibleForceNameUpdate[4];
 		u8 playerBeingDragged;
 };
 

--- a/Chkdraft/Source Files/GuiMap.cpp
+++ b/Chkdraft/Source Files/GuiMap.cpp
@@ -32,6 +32,19 @@ GuiMap::~GuiMap()
 	DeleteDC(MemMinihDC);
 }
 
+bool GuiMap::CanExit()
+{
+	if ( unsavedChanges )
+	{
+		int result = MessageBox(NULL, "Save Changes?", MapFile::FilePath(), MB_YESNOCANCEL);
+		if ( result == IDYES )
+			SaveFile(false);
+		else if ( result == IDCANCEL )
+			return false;
+	}
+	return true;
+}
+
 bool GuiMap::SaveFile(bool saveAs)
 {
 	if ( MapFile::SaveFile(saveAs) )
@@ -1288,6 +1301,7 @@ LRESULT GuiMap::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 		case WM_HSCROLL: return HorizontalScroll(hWnd, msg, wParam, lParam); break;
 		case WM_VSCROLL: return VerticalScroll(hWnd, msg, wParam, lParam); break;
 		case WM_SIZE: return DoSize(hWnd, wParam, lParam); break;
+		case WM_CLOSE: return ConfirmWindowClose(hWnd); break;
 		case WM_DESTROY: return DestroyWindow(hWnd); break;
 		case WM_RBUTTONUP: RButtonUp(); break;
 		case WM_LBUTTONDBLCLK: LButtonDoubleClick(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)); break;
@@ -1947,4 +1961,12 @@ void GuiMap::UnitLButtonUp(HWND hWnd, int mapX, int mapY, WPARAM wParam)
 		}
 	}
 	Redraw(true);
+}
+
+LRESULT GuiMap::ConfirmWindowClose(HWND hWnd)
+{
+	if ( CanExit() )
+		return DefMDIChildProc(hWnd, WM_CLOSE, NULL, NULL);
+	else
+		return 0;
 }

--- a/Chkdraft/Source Files/GuiMap.h
+++ b/Chkdraft/Source Files/GuiMap.h
@@ -15,7 +15,8 @@ class GuiMap : public MapFile, public ClassWindow
 
 /*  Destructor  */	~GuiMap();
 
-/*	  File IO	*/	bool SaveFile(bool saveAs);
+/*	  File IO	*/	bool CanExit();
+					bool SaveFile(bool saveAs);
 
 /*   Chk Accel  */	// Sets the given tile to the given tileNum
 					bool SetTile(s32 x, s32 y, u16 tileNum);
@@ -177,6 +178,7 @@ class GuiMap : public MapFile, public ClassWindow
 					void TerrainLButtonUp(HWND hWnd, int mapX, int mapY, WPARAM wParam);
 					void LocationLButtonUp(HWND hWnd, int mapX, int mapY, WPARAM wParam);
 					void UnitLButtonUp(HWND hWnd, int mapX, int mapY, WPARAM wParam);
+					LRESULT ConfirmWindowClose(HWND hWnd);
 
 };
 

--- a/Chkdraft/Source Files/MapProperties.cpp
+++ b/Chkdraft/Source Files/MapProperties.cpp
@@ -1,8 +1,16 @@
 #include "MapProperties.h"
 #include "Chkdraft.h"
 
+MapPropertiesWindow::MapPropertiesWindow() : possibleTitleUpdate(false), possibleDescriptionUpdate(false)
+{
+
+}
+
 bool MapPropertiesWindow::CreateThis(HWND hParent)
 {
+	if ( getHandle() != NULL )
+		return SetParent(getHandle(), hParent) != NULL;
+
 	if ( ClassWindow::RegisterWindowClass(NULL, NULL, NULL, NULL, NULL, "MapProperties", NULL, false) &&
 		 ClassWindow::CreateClassWindow(NULL, "MapProperties", WS_VISIBLE|WS_CHILD, 4, 22, 592, 524, hParent, (HMENU)ID_MAPPROPERTIES) )
 	{
@@ -102,6 +110,8 @@ LRESULT MapPropertiesWindow::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM 
 
 					SetWindowText(GetDlgItem(hWnd, ID_EDIT_MAPTITLE), mapTitle.c_str());
 					SetWindowText(GetDlgItem(hWnd, ID_EDIT_MAPDESCRIPTION), mapDescription.c_str());
+					possibleTitleUpdate = false;
+					possibleDescriptionUpdate = false;
 					SendMessage(GetDlgItem(hWnd, ID_CB_MAPTILESET), CB_SETCURSEL, tileset, NULL);
 					PostMessage(GetDlgItem(hWnd, ID_CB_MAPTILESET), CB_SETEDITSEL, NULL, (-1, 0));
 					SendMessage(GetDlgItem(hWnd, ID_CB_NEWMAPTERRAIN), CB_SETCURSEL, 0, NULL);
@@ -145,12 +155,16 @@ LRESULT MapPropertiesWindow::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM 
 				switch ( LOWORD(wParam) )
 				{
 					case ID_EDIT_MAPTITLE:
-						if ( HIWORD(wParam) == EN_KILLFOCUS )
+						if ( HIWORD(wParam) == EN_CHANGE )
+							possibleTitleUpdate = true;
+						else if ( HIWORD(wParam) == EN_KILLFOCUS )
 							CheckReplaceMapTitle();
 						break;
 
 					case ID_EDIT_MAPDESCRIPTION:
-						if ( HIWORD(wParam) == EN_KILLFOCUS )
+						if ( HIWORD(wParam) == EN_CHANGE )
+							possibleDescriptionUpdate = true;
+						else if ( HIWORD(wParam) == EN_KILLFOCUS )
 							CheckReplaceMapDescription();
 						break;
 
@@ -278,7 +292,7 @@ LRESULT MapPropertiesWindow::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM 
 void MapPropertiesWindow::CheckReplaceMapTitle()
 {
 	string newMapTitle;
-	if ( GetEditText(GetDlgItem(getHandle(), ID_EDIT_MAPTITLE), newMapTitle) )
+	if ( possibleTitleUpdate == true && GetEditText(GetDlgItem(getHandle(), ID_EDIT_MAPTITLE), newMapTitle) )
 	{
 		u16* mapTitleString;
 		if ( chkd.maps.curr->SPRP().getPtr<u16>(mapTitleString, 0, 2) &&
@@ -287,13 +301,14 @@ void MapPropertiesWindow::CheckReplaceMapTitle()
 		{
 			chkd.maps.curr->notifyChange(false);
 		}
+		possibleTitleUpdate = false;
 	}
 }
 
 void MapPropertiesWindow::CheckReplaceMapDescription()
 {
 	string newMapDescription;
-	if ( GetEditText(GetDlgItem(getHandle(), ID_EDIT_MAPDESCRIPTION), newMapDescription) )
+	if ( possibleDescriptionUpdate == true && GetEditText(GetDlgItem(getHandle(), ID_EDIT_MAPDESCRIPTION), newMapDescription) )
 	{
 		u16* mapDescriptionString;
 		if ( chkd.maps.curr->SPRP().getPtr<u16>(mapDescriptionString, 2, 2) &&
@@ -302,5 +317,6 @@ void MapPropertiesWindow::CheckReplaceMapDescription()
 		{
 			chkd.maps.curr->notifyChange(false);
 		}
+		possibleDescriptionUpdate = false;
 	}
 }

--- a/Chkdraft/Source Files/MapProperties.h
+++ b/Chkdraft/Source Files/MapProperties.h
@@ -7,12 +7,16 @@
 class MapPropertiesWindow : public ClassWindow
 {
 	public:
+		MapPropertiesWindow();
 		bool CreateThis(HWND hParent);
 
 	private:
 		LRESULT WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 		void CheckReplaceMapTitle();
 		void CheckReplaceMapDescription();
+
+		bool possibleTitleUpdate;
+		bool possibleDescriptionUpdate;
 
 		ButtonControl buttonApply;
 };

--- a/Chkdraft/Source Files/MapSettings.cpp
+++ b/Chkdraft/Source Files/MapSettings.cpp
@@ -13,7 +13,10 @@ bool MapSettingsWindow::CreateThis(HWND hParent)
 
 bool MapSettingsWindow::DestroyThis()
 {
-	return ClassWindow::DestroyDialog();
+	currTab = 0;
+	hTabs = NULL;
+	ClassWindow::DestroyDialog();
+	return true;
 }
 
 void MapSettingsWindow::ChangeTab(u32 tabID)

--- a/Chkdraft/Source Files/Mapping Core/Scenario.cpp
+++ b/Chkdraft/Source Files/Mapping Core/Scenario.cpp
@@ -952,7 +952,11 @@ bool Scenario::replaceString(string newString, numType& stringNum, bool extended
 
 	if ( stringNum != 0 && amountStringUsed(stringNum) == 1 )
 	{
-		return editString<numType>(newString, stringNum, extended, safeReplace);
+		string testEqual;
+		if ( getString(testEqual, oldStringNum) && testEqual.compare(newString) == 0 )
+			return false;
+		else
+			return editString<numType>(newString, stringNum, extended, safeReplace);
 	}
 	else if ( stringExists(newString, newStringNum, extended) )
 	{

--- a/Chkdraft/Source Files/StringEditor.cpp
+++ b/Chkdraft/Source Files/StringEditor.cpp
@@ -8,6 +8,9 @@ StringEditorWindow::StringEditorWindow() : currSelString(0)
 
 bool StringEditorWindow::CreateThis(HWND hParent)
 {
+	if ( getHandle() != NULL )
+		return SetParent(getHandle(), hParent) != NULL;
+
 	if ( ClassWindow::RegisterWindowClass(NULL, NULL, NULL, NULL, NULL, "StringEditor", NULL, false) &&
 		 ClassWindow::CreateClassWindow(NULL, "", WS_VISIBLE|WS_CHILD, 4, 22, 592, 524, hParent, (HMENU)ID_STRINGEDITOR) )
 	{

--- a/Chkdraft/Source Files/TechSettings.cpp
+++ b/Chkdraft/Source Files/TechSettings.cpp
@@ -8,6 +8,9 @@ TechSettingsWindow::TechSettingsWindow() : selectedTech(0)
 
 bool TechSettingsWindow::CreateThis(HWND hParent)
 {
+	if ( getHandle() != NULL )
+		return SetParent(getHandle(), hParent) != NULL;
+
 	if ( ClassWindow::RegisterWindowClass(NULL, NULL, NULL, NULL, NULL, "TechSettings", NULL, false) &&
 		 ClassWindow::CreateClassWindow(NULL, "TechSettings", WS_VISIBLE|WS_CHILD, 4, 22, 592, 524, hParent, (HMENU)ID_TECHSETTINGS) )
 	{
@@ -100,7 +103,8 @@ void TechSettingsWindow::CreateSubWindows(HWND hWnd)
 		dropPlayerTechSettings[player].CreateThis(hWnd, 460, 210+20*player, 120, 100, false, ID_DROP_P1TECHSETTINGS, 3, playerTechSettings, defaultFont);
 	}
 
-	//DisableTechEditing();
+	buttonResetTechDefaults.DisableThis();
+	DisableTechEditing();
 }
 
 void TechSettingsWindow::DisableTechCosts()

--- a/Chkdraft/Source Files/UnitSettings.cpp
+++ b/Chkdraft/Source Files/UnitSettings.cpp
@@ -2,6 +2,9 @@
 
 bool UnitSettingsWindow::CreateThis(HWND hParent)
 {
+	if ( getHandle() != NULL )
+		return SetParent(getHandle(), hParent) != NULL;
+
 	if ( ClassWindow::RegisterWindowClass(NULL, NULL, NULL, NULL, NULL, "UnitSettings", NULL, false) &&
 		 ClassWindow::CreateClassWindow(NULL, "UnitSettings", WS_VISIBLE|WS_CHILD, 4, 22, 592, 524, hParent, (HMENU)ID_UNITSETTINGS) )
 	{
@@ -10,6 +13,11 @@ bool UnitSettingsWindow::CreateThis(HWND hParent)
 	}
 	else
 		return false;
+}
+
+bool UnitSettingsWindow::DestroyThis()
+{
+	return true;
 }
 
 LRESULT UnitSettingsWindow::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)

--- a/Chkdraft/Source Files/UnitSettings.h
+++ b/Chkdraft/Source Files/UnitSettings.h
@@ -8,6 +8,7 @@ class UnitSettingsWindow : public ClassWindow
 {
 	public:
 		bool CreateThis(HWND hParent);
+		bool DestroyThis();
 
 	private:
 		LRESULT WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/Chkdraft/Source Files/UpgradeSettings.cpp
+++ b/Chkdraft/Source Files/UpgradeSettings.cpp
@@ -3,6 +3,9 @@
 
 bool UpgradeSettingsWindow::CreateThis(HWND hParent)
 {
+	if ( getHandle() != NULL )
+		return SetParent(getHandle(), hParent) != NULL;
+
 	if ( ClassWindow::RegisterWindowClass(NULL, NULL, NULL, NULL, NULL, "UpgradeSettings", NULL, false) &&
 		 ClassWindow::CreateClassWindow(NULL, "UpgradeSettings", WS_VISIBLE|WS_CHILD, 4, 22, 592, 524, hParent, (HMENU)ID_UPGRADESETTINGS) )
 	{

--- a/Chkdraft/Source Files/WavEditor.cpp
+++ b/Chkdraft/Source Files/WavEditor.cpp
@@ -3,6 +3,9 @@
 
 bool WavEditorWindow::CreateThis(HWND hParent)
 {
+	if ( getHandle() != NULL )
+		return SetParent(getHandle(), hParent) != NULL;
+
 	if ( ClassWindow::RegisterWindowClass(NULL, NULL, NULL, NULL, NULL, "WavEditor", NULL, false) &&
 		 ClassWindow::CreateClassWindow(NULL, "WavEditor", WS_VISIBLE|WS_CHILD, 4, 22, 592, 524, hParent, (HMENU)ID_WAVEDITOR) )
 	{


### PR DESCRIPTION
Feature Changes:
- Confirm exit dialog

Bug/Error Fixes:
- Fixed a bug where map settings would not display for a second map
- Fixed a bug where map settings would flag a change where there was
  none
- Removed delay that would occur with switching from map props/forces
  tab

Code Changes:
- Scenario::replaceString now returns false if the replacement string is
  the same as the original
