### PR TITLE
Fixed Toolbar Initialize

### DIFF
--- a/Chkdraft/Source Files/MainToolbar.cpp
+++ b/Chkdraft/Source Files/MainToolbar.cpp
@@ -46,12 +46,14 @@ bool MainToolbar::CreateThis(HWND hParent)
 									   "Copy\\Cut\\Paste\\Brush" };
 		layerBox.CreateThis(hTool, 277, 2, 110, 200, false, ID_COMBOBOX_LAYER, 8, layerStrings, defaultFont);
 		layerBox.SetSel(0);
+		ShowWindow(layerBox.getHandle(), SW_HIDE); // Hide until a map is open
 
 		// Add zoom ComboBox to toolbar
 		const char* zoomStrings[] = { "400% Zoom", "300% Zoom", "200% Zoom", "150% Zoom", "100% Zoom", "66% Zoom",
 									  "50% Zoom", "33% Zoom", "25% Zoom", "10% Zoom"};
 		zoomBox.CreateThis(hTool, 395, 2, 80, 200, false, ID_COMBOBOX_ZOOM, 10, zoomStrings, defaultFont);
 		zoomBox.SetSel(4);
+		ShowWindow(zoomBox.getHandle(), SW_HIDE); // Hide until a map is open
 
 		// Add player ComboBox to toolbar
 		const char* playerStrings[] = { "Player 01", "Player 02", "Player 03", "Player 04", "Player 05", "Player 06",
@@ -59,11 +61,13 @@ bool MainToolbar::CreateThis(HWND hParent)
 		playerBox.CreateThis(hTool, 483, 2, 75, 200, true, ID_COMBOBOX_PLAYER, 12, playerStrings, defaultFont);
 		playerBox.SetSel(0);
 		playerBox.ClearEditSel();
+		ShowWindow(playerBox.getHandle(), SW_HIDE); // Hide until a map is open
 
 		// Add terrain ComboBox to toolbar			
 		const char* terrPalette[] = { "Isometrical", "Rectangular", "Subtile", "Tileset Indexed", "Copy/Cut/Paste" };
 		terrainBox.CreateThis(hTool, 483, 2, 100, 200, false, ID_COMBOBOX_TERRAIN, 5, terrPalette, defaultFont);
 		terrainBox.SetSel(0);
+		ShowWindow(terrainBox.getHandle(), SW_HIDE); // Hide until a map is open
 
 		return true;
 	}


### PR DESCRIPTION
Toolbar comboboxes now properly hidden on create, as such the player
combobox won't bleed through the terrain combobox when you open a map.
