### PR TITLE
Reset All Unit/Upgrade Settings Fix

### DIFF
--- a/Chkdraft/Source Files/UnitSettings.cpp
+++ b/Chkdraft/Source Files/UnitSettings.cpp
@@ -511,13 +511,22 @@ LRESULT UnitSettingsWindow::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 					{
 						if ( MessageBox(hWnd, "Are you sure you want to reset all unit settings?", "Confirm", MB_YESNO) == IDYES )
 						{
-							buffer newUNIS, newUNIx, newPUNI;
+							buffer newUNIS("UNIS"), newUNIx("UNIx"), newPUNI("PUNI");
 							if ( Get_UNIS(newUNIS) )
+							{
+								newUNIS.del(0, 8);
 								chkd.maps.curr->UNIS().takeAllData(newUNIS);
+							}
 							if ( Get_UNIx(newUNIx) )
+							{
+								newUNIx.del(0, 8);
 								chkd.maps.curr->UNIx().takeAllData(newUNIx);
+							}
 							if ( Get_PUNI(newPUNI) )
+							{
+								newPUNI.del(0, 8);
 								chkd.maps.curr->PUNI().takeAllData(newPUNI);
+							}
 
 							chkd.maps.curr->cleanStringTable(false);
 							chkd.maps.curr->cleanStringTable(true);

--- a/Chkdraft/Source Files/UpgradeSettings.cpp
+++ b/Chkdraft/Source Files/UpgradeSettings.cpp
@@ -410,15 +410,27 @@ LRESULT UpgradeSettingsWindow::WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARA
 						{
 							if ( MessageBox(hWnd, "Are you sure you want to reset all ugprade settings?", "Confirm", MB_YESNO) == IDYES )
 							{
-								buffer newUNIS, newUNIx, newUPGR, newPUPx;
-								if ( Get_UNIS(newUNIS) )
-									chkd.maps.curr->UNIS().takeAllData(newUNIS);
-								if ( Get_UNIx(newUNIx) )
-									chkd.maps.curr->UNIx().takeAllData(newUNIx);
+								buffer newUPGS("UPGS"), newUPGx("UPGx"), newUPGR("UPGR"), newPUPx("PUPx");
+								if ( Get_UPGS(newUPGS) )
+								{
+									newUPGS.del(0, 8);
+									chkd.maps.curr->UPGS().takeAllData(newUPGS);
+								}
+								if ( Get_UPGx(newUPGx) )
+								{
+									newUPGx.del(0, 8);
+									chkd.maps.curr->UPGx().takeAllData(newUPGx);
+								}
 								if ( Get_UPGR(newUPGR) )
+								{
+									newUPGR.del(0, 8);
 									chkd.maps.curr->UPGR().takeAllData(newUPGR);
+								}
 								if ( Get_PUPx(newPUPx) )
+								{
+									newPUPx.del(0, 8);
 									chkd.maps.curr->PUPx().takeAllData(newPUPx);
+								}
 
 								DisableCostEditing();
 								RefreshWindow();


### PR DESCRIPTION
- Fixed a bug where unit/upgrade settings replace all was misaligned by
  8 bytes, potentially causing serious problems if used.
