### PR TITLE
Bug Fixes, Location Properties Cleanup

### DIFF
--- a/Chkdraft/Chkdraft.vcxproj
+++ b/Chkdraft/Chkdraft.vcxproj
@@ -323,7 +323,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>
       </AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PreprocessorDefinitions>USESTATICSFMPQ;CHKDRAFT;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_DEPRECATE;_USING_V110_SDK71_;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
@@ -331,7 +331,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>SFMPQ/SFmpq_MT.lib;comctl32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SFmpq\SFmpq.lib;comctl32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ImageHasSafeExceptionHandlers>true</ImageHasSafeExceptionHandlers>
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/Chkdraft/Chkdraft.vcxproj.filters
+++ b/Chkdraft/Chkdraft.vcxproj.filters
@@ -561,9 +561,6 @@
     <ClInclude Include="src\WindowsUI\MdiClient.h">
       <Filter>Header Files\Windows UI\Windows</Filter>
     </ClInclude>
-    <ClInclude Include="SFmpq\SFmpqapi.h">
-      <Filter>Header Files\Mapping Core\%2a</Filter>
-    </ClInclude>
     <ClInclude Include="src\Undos.h">
       <Filter>Header Files\Mapping\Undos</Filter>
     </ClInclude>
@@ -575,6 +572,9 @@
     </ClInclude>
     <ClInclude Include="src\CommonFiles\Resource.h">
       <Filter>Header Files\Common Files</Filter>
+    </ClInclude>
+    <ClInclude Include="SFmpq\SFmpqapi.h">
+      <Filter>Header Files\Mapping Core\%2a</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Chkdraft/src/CommonFiles/Debug.h
+++ b/Chkdraft/src/CommonFiles/Debug.h
@@ -3,7 +3,7 @@
 #include "Constants.h"
 
 // If defined, a standard output window will be shown
-#define SHOW_CLI
+//#define SHOW_CLI
 
 /** CHKD_DEBUG is usually only defined if visual studios is set
     to compile in debug mode, however it can ocassionally be

--- a/Chkdraft/src/Graphics.cpp
+++ b/Chkdraft/src/Graphics.cpp
@@ -241,7 +241,7 @@ void Graphics::DrawLocations(ChkdBitmap& bitmap, bool showAnywhere)
 
     for ( u16 locNum = 0; locNum < map.locationCapacity(); locNum++ )
     {
-        if ( map.getLocation(loc, locNum) )
+        if ( (locNum != 63 || showAnywhere) && map.getLocation(loc, locNum) )
         {
             s32 leftMost = std::min(loc->xc1, loc->xc2);
             if ( leftMost < screenRight )

--- a/Chkdraft/src/GuiMap.cpp
+++ b/Chkdraft/src/GuiMap.cpp
@@ -624,7 +624,7 @@ void GuiMap::undo()
                 //undoStacks.doUndo(UNDO_LOCATION, scenario(), selections());
                 if ( chkd.locationWindow.getHandle() != NULL )
                 {
-                    if ( CM->numLocations() == 0 )
+                    if ( CM->numLocations() > 0 )
                         chkd.locationWindow.RefreshLocationInfo();
                     else
                         chkd.locationWindow.DestroyThis();

--- a/Chkdraft/src/LocationProperties.h
+++ b/Chkdraft/src/LocationProperties.h
@@ -13,22 +13,47 @@ class LocationWindow : public ClassDialog
         void RefreshLocationInfo();
 
     protected:
-        void RefreshLocationElevationFlags(ChkLocation* locRef, HWND hWnd);
-        BOOL DlgCommand(HWND hWnd, WPARAM wParam, LPARAM lParam);
+        void RefreshLocationElevationFlags();
+
+        void InvertXc();
+        void InvertYc();
+        void InvertXY();
+
+        void NotifyLowGroundClicked();
+        void NotifyMedGroundClicked();
+        void NotifyHighGroundClicked();
+        void NotifyLowAirClicked();
+        void NotifyMedAirClicked();
+        void NotifyHighAirClicked();
+        void NotifyUseExtendedStringClicked();
+
+        void RawFlagsUpdated();
+        void LocationLeftUpdated();
+        void LocationTopUpdated();
+        void LocationRightUpdated();
+        void LocationBottomUpdated();
+
+        void LocationNameFocusLost();
+        void RawFlagsFocusLost();
+        void LocationLeftFocusLost();
+        void LocationTopFocusLost();
+        void LocationRightFocusLost();
+        void LocationBottomFocusLost();
+
+        virtual void NotifyButtonClicked(int idFrom, HWND hWndFrom); // Sent when a button or checkbox is clicked
+        virtual void NotifyEditUpdated(int idFrom, HWND hWndFrom); // Sent when edit text changes, before redraw
+        virtual void NotifyEditFocused(int idFrom, HWND hWndFrom); // Sent when an edit box receives focus
+        virtual void NotifyEditFocusLost(int idFrom, HWND hWndFrom); // Sent when focus changes or the window is hidden
         BOOL DlgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
     private:
-        bool initializing;
+        bool refreshing;
         u32 preservedStat;
-        u16 locProcLocIndex;
+        u16 currentLocationIndex;
 
-        CheckBoxControl checkUseExtended;
-        EditControl editLocName;
-        EditControl editLocLeft;
-        EditControl editLocTop;
-        EditControl editLocRight;
-        EditControl editLocBottom;
-        EditControl editRawFlags;
+        EditControl editLocName, editLocLeft, editLocTop, editLocRight, editLocBottom, editRawFlags;
+        CheckBoxControl checkUseExtended, checkLowGround, checkMedGround, checkHighGround, checkLowAir, checkMedAir, checkHighAir;
+        ButtonControl buttonInvertX, buttonInvertY, buttonInvertXY;
 };
 
 #endif

--- a/Chkdraft/src/MappingCore/MapFile.cpp
+++ b/Chkdraft/src/MappingCore/MapFile.cpp
@@ -25,6 +25,8 @@ bool MapFile::LoadFile()
 
 bool MapFile::SaveFile(bool SaveAs)
 {
+    std::string prevFilePath(filePath);
+
     if ( isProtected() )
         MessageBox(NULL, "Cannot save protected maps!", "Error!", MB_OK|MB_ICONEXCLAMATION);
     else
@@ -68,7 +70,7 @@ bool MapFile::SaveFile(bool SaveAs)
 
         if ( filePath[0] != '\0' ) // Map for sure has a path
         {
-            FILE* pFile(nullptr);
+            std::FILE* pFile(nullptr);
 
             if ( saveType == SaveType::StarCraftScm || saveType == SaveType::StarCraftChk ) // StarCraft Map, edit to match
                 ChangeToScOrig();
@@ -81,39 +83,34 @@ bool MapFile::SaveFile(bool SaveAs)
             }
 
             if ( (saveType == SaveType::StarCraftScm || saveType == SaveType::HybridScm || saveType == SaveType::ExpansionScx)
-                 || saveType == SaveType::AllMaps ) // Must be packed into an MPQ
+                || saveType == SaveType::AllMaps ) // Must be packed into an MPQ
             {
-                pFile = std::fopen(filePath, "wb");
-                if ( pFile != nullptr )
+                if ( !SaveAs || (SaveAs && MakeFileCopy(prevFilePath, filePath)) )
                 {
-                    std::fclose(pFile);
-                    HANDLE hMpq = NULL;
                     DeleteFileA("chk.tmp"); // Remove any existing chk.tmp files
                     pFile = std::fopen("chk.tmp", "wb");
                     WriteFile(pFile);
                     std::fclose(pFile);
 
-                    hMpq = MpqOpenArchiveForUpdate(filePath, MOAU_OPEN_ALWAYS|MOAU_MAINTAIN_LISTFILE, 16);
+                    MPQHANDLE hMpq = MpqOpenArchiveForUpdate(filePath, MOAU_OPEN_EXISTING | MOAU_MAINTAIN_LISTFILE, 1000);
                     if ( hMpq != NULL && hMpq != INVALID_HANDLE_VALUE )
                     {
                         BOOL addedFile = MpqAddFileToArchive(hMpq, "chk.tmp", "staredit\\scenario.chk", MAFA_COMPRESS | MAFA_REPLACE_EXISTING);
                         MpqCloseUpdatedArchive(hMpq, 0);
-
                         if ( addedFile == TRUE )
                         {
                             DeleteFileA("chk.tmp");
                             return true;
                         }
                         else
-                            MessageBox(NULL, "Failed to add file!", "Error!", MB_OK|MB_ICONEXCLAMATION);
+                            MessageBox(NULL, "Failed to add file!", "Error!", MB_OK | MB_ICONEXCLAMATION);
                     }
                     else
-                        MessageBox(NULL, "Failed to open for updates!", "Error!", MB_OK|MB_ICONEXCLAMATION);
-
-                    DeleteFileA("chk.tmp");
+                        MessageBox(NULL, std::string(std::string("Failed to open for updates!\n\nThe file may be in use elsewhere. ") + std::to_string(GetLastError())).c_str(), "Error!", MB_OK | MB_ICONEXCLAMATION);
                 }
-                else
-                    MessageBox(NULL, "Failed to open file!\n\nThe file may be in use elsewhere.", "Error!", MB_OK|MB_ICONEXCLAMATION);
+                MessageBox(NULL, "Failed to create the new MPQ file!", "Error!", MB_OK | MB_ICONEXCLAMATION);
+
+                DeleteFileA("chk.tmp");
             }
             else // Is a chk file or unrecognized format, write out chk file
             {
@@ -172,12 +169,14 @@ bool MapFile::OpenFile()
         {
             if ( strcmp(ext, ".scm") == 0 || strcmp(ext, ".scx") == 0 )
             {
-                HANDLE hMpq = MpqOpenArchiveForUpdate(filePath, MOAU_OPEN_EXISTING, 1000);
-
+                MPQHANDLE hMpq = MpqOpenArchiveForUpdate(filePath, MOAU_OPEN_EXISTING|MOAU_READ_ONLY, 1000);
                 if ( hMpq != NULL && hMpq != INVALID_HANDLE_VALUE )
                 {
-                    FileToBuffer(hMpq, "staredit\\scenario.chk", chk);
+                    if ( !FileToBuffer(hMpq, "staredit\\scenario.chk", chk) )
+                        CHKD_ERR("Failed to get scenario file from MPQ.");
+
                     MpqCloseUpdatedArchive(hMpq, 0);
+                    
 
                     if ( chk.size() > 0 && ParseScenario(chk) )
                     {
@@ -197,6 +196,8 @@ bool MapFile::OpenFile()
 
                         return true;
                     }
+                    else
+                        CHKD_ERR("Invalid or missing Scenario file.");
                 }
                 else if ( GetLastError() == ERROR_FILE_NOT_FOUND )
                     CHKD_ERR("File Not Found");


### PR DESCRIPTION
- Fixed a critical error where map MPQs were overridden with a blank
file before saving (deleted non-virtual WAVs).
- Fixed a bug where the anywhere location was rendered while locked.
- Fixed a bug where the location properties window would close when
undoing and the result was the map having more than zero locations,
rather than when it had zero locations.
- Cleaned up LocationProperties (broke up the giant switch, general
touchups).