### PR TITLE
Auto-Save MPQ Locations

### DIFF
--- a/Chkdraft/src/MappingCore/FileIO.cpp
+++ b/Chkdraft/src/MappingCore/FileIO.cpp
@@ -129,7 +129,7 @@ bool OpenArchive(const char* mpqPath, MPQHANDLE &mpq)
     return success == TRUE;
 }
 
-bool OpenArchive(const char* directory, const char* fileName, MPQHANDLE &hMpq)
+bool OpenArchive(const char* directory, const char* fileName, MPQHANDLE &hMpq, std::string &outPath)
 {
     BOOL success = FALSE;
     char filePath[MAX_PATH],
@@ -144,6 +144,8 @@ bool OpenArchive(const char* directory, const char* fileName, MPQHANDLE &hMpq)
     {
         do { success = SFileOpenArchive((LPCSTR)filePath, 0, 0, &hMpq); }
         while ( success == FALSE && MessageBox(NULL, retryError, "Error!", MB_YESNO|MB_ICONEXCLAMATION) == IDYES );
+        if ( success == TRUE )
+            outPath = filePath;
     }
     else // File not found
     {
@@ -162,9 +164,11 @@ bool OpenArchive(const char* directory, const char* fileName, MPQHANDLE &hMpq)
             {
                 do { success = SFileOpenArchive(filePath, 0, 0, &hMpq); }
                 while ( success == FALSE && MessageBox(NULL, retryError, "Error!", MB_YESNO|MB_ICONEXCLAMATION) == IDYES );
+                if ( success == TRUE )
+                    outPath = filePath;
             }
             else
-                return OpenArchive(directory, fileName, hMpq);
+                return OpenArchive(directory, fileName, hMpq, outPath);
         }
     }
     return success == TRUE;

--- a/Chkdraft/src/MappingCore/FileIO.h
+++ b/Chkdraft/src/MappingCore/FileIO.h
@@ -23,7 +23,7 @@ bool PatientFindFile(const char* filePath, int numWaitTimes, int* waitTimes);
 
 bool OpenArchive(const char* mpqPath, MPQHANDLE &mpq);
 
-bool OpenArchive(const char* directory, const char* mpqName, MPQHANDLE &hMpq);
+bool OpenArchive(const char* directory, const char* mpqName, MPQHANDLE &hMpq, std::string &outPath);
 
 bool CloseArchive(MPQHANDLE mpq);
 


### PR DESCRIPTION
Chkdraft now auto-saves manually selected MPQ locations and allows these
to be edited in the settings file.