### PR TITLE
Development

### DIFF
--- a/Chkdraft/src/Chkdraft.cpp
+++ b/Chkdraft/src/Chkdraft.cpp
@@ -21,9 +21,9 @@ enum MainWindow {
 
 void Chkdraft::OnLoadTest()
 {
-    /*if ( maps.OpenMap("C:\\Users\\Justin\\Desktop\\StarCraft 1.16.1\\Maps\\BroodWar\\Helms Deep AnnaModz 8.4.scx") )
-    //maps.NewMap(128, 128, 2, 0, 0);
-    {
+    /*if ( maps.OpenMap("C:\\Users\\Justin\\Desktop\\StarCraft 1.16.1\\Maps\\BroodWar\\Helms Deep AnnaModz 8.4.scx") )*/
+    //maps.NewMap(128, 128, Tileset::TERRAIN_INSTALLATION, 0, 0);
+    /*{
         //ShowWindow(getHandle(), SW_MAXIMIZE); // If a maximized window is desirable for testing
 
         trigEditorWindow.CreateThis(getHandle());
@@ -90,14 +90,19 @@ int Chkdraft::Run(LPSTR lpCmdLine, int nCmdShow)
 
 void Chkdraft::SetupLogging()
 {
-    logger.setOutputStream(std::shared_ptr<std::ostream>(&std::cout));
+    logger.setOutputStream(std::shared_ptr<std::ostream>(&std::cout, [](std::ostream* os) { /* Do nothing when this goes out of scope */ }));
 
     std::string loggerPath;
     if ( GetLoggerPath(loggerPath) )
     {
         std::string logFilePath = loggerPath + Logger::getTimestamp();
         logger.info("Setting log file to: " + logFilePath);
-        logFile.setOutputStream(std::shared_ptr<std::ostream>(new std::ofstream(logFilePath)));
+        logFile.setOutputStream(std::shared_ptr<std::ostream>(new std::ofstream(logFilePath), [](std::ostream* os) {
+            if ( os != nullptr ) { // Close and delete when output stream goes out of scope
+                ((std::ofstream*)os)->close();
+                delete os;
+            }
+        }));
         logger.setAggregator(&logFile); // Forwards all logger messages to the log file, which will then save messages based on their importance
     }
     else

--- a/Chkdraft/src/Logger.cpp
+++ b/Chkdraft/src/Logger.cpp
@@ -7,7 +7,7 @@ Logger::Logger() : outputStream(nullptr), maximumLogLevel(LogLevel::Info)
 
 }
 
-Logger::Logger(LogLevel logLevel) : maximumLogLevel(logLevel)
+Logger::Logger(LogLevel logLevel) : outputStream(nullptr), maximumLogLevel(logLevel)
 {
 
 }

--- a/Chkdraft/src/Logger.h
+++ b/Chkdraft/src/Logger.h
@@ -3,6 +3,7 @@
 #include <exception>
 #include <cstdint>
 #include <iostream>
+#include <fstream>
 #include <memory>
 #include <vector>
 

--- a/Chkdraft/src/MappingCore/MapFile.cpp
+++ b/Chkdraft/src/MappingCore/MapFile.cpp
@@ -52,7 +52,11 @@ bool MapFile::SaveFile(bool SaveAs)
                 mapFilePath = szFilePath;
                 saveType = (SaveType)ofn.nFilterIndex;
 
-                const char* ext = std::strrchr(mapFilePath.c_str(), '.'); // Find the last occurrence of '.'
+                const char* fileName = std::strrchr(mapFilePath.c_str(), '\\');
+                const char* ext = nullptr;
+                if ( fileName != nullptr )
+                    ext = std::strrchr(fileName, '.'); // Find the last occurrence of '.'
+
                 if ( ext == nullptr ) // No extension specified, need to add
                 {
                     if ( saveType == SaveType::StarCraftScm || saveType == SaveType::HybridScm )
@@ -67,7 +71,10 @@ bool MapFile::SaveFile(bool SaveAs)
                     if ( std::strcmp(ext, ".chk") == 0 && (saveType == SaveType::StarCraftScm || saveType == SaveType::HybridScm ||
                         saveType == SaveType::ExpansionScx) )
                     {
-                        saveType = SaveType::HybridChk;
+                        if ( saveType == SaveType::ExpansionScx )
+                            saveType = SaveType::ExpansionChk;
+                        else
+                            saveType = SaveType::HybridChk;
                     }
                     else if ( std::strcmp(ext, ".scm") == 0 && saveType != SaveType::StarCraftScm )
                         saveType = SaveType::HybridScm;
@@ -96,8 +103,6 @@ bool MapFile::SaveFile(bool SaveAs)
             if ( (saveType == SaveType::StarCraftScm || saveType == SaveType::HybridScm || saveType == SaveType::ExpansionScx)
                 || saveType == SaveType::AllMaps ) // Must be packed into an MPQ
             {
-                if ( !SaveAs || (SaveAs && MakeFileCopy(prevFilePath, mapFilePath)) )
-                {
                     DeleteFileA("chk.tmp"); // Remove any existing chk.tmp files
                     pFile = std::fopen("chk.tmp", "wb");
                     Scenario::WriteFile(pFile);
@@ -125,7 +130,7 @@ bool MapFile::SaveFile(bool SaveAs)
                     }
                     else
                         MessageBox(NULL, std::string(std::string("Failed to open for updates!\n\nThe file may be in use elsewhere. ") + std::to_string(GetLastError())).c_str(), "Error!", MB_OK | MB_ICONEXCLAMATION);
-                }
+                    
                 MessageBox(NULL, "Failed to create the new MPQ file!", "Error!", MB_OK | MB_ICONEXCLAMATION);
 
                 DeleteFileA("chk.tmp");

--- a/Chkdraft/src/MappingCore/Scenario.cpp
+++ b/Chkdraft/src/MappingCore/Scenario.cpp
@@ -105,29 +105,32 @@ bool Scenario::IsScExp()
 
 bool Scenario::ChangeToScOrig()
 {
-    return TYPE().overwrite("RAWS", 4) &&
-        VER().overwrite(";\0", 2) &&
-        IVER().overwrite("\12\0", 2) &&
-        IVE2().overwrite("\13\0", 2) &&
-        (MRGN().size() <= 1280 || MRGN().delRange(1280, MRGN().size()));
+    bool success = TYPE().overwrite("RAWS", 4);
+    success |= VER().overwrite(";\0", 2);
+    success |= IVER().overwrite("\12\0", 2);
+    success |= IVE2().overwrite("\13\0", 2);
+    success |= (MRGN().size() <= 1280 || MRGN().delRange(1280, MRGN().size()));
+    return success;
 }
 
 bool Scenario::ChangeToHybrid()
 {
-    return TYPE().overwrite("RAWS", 4) &&
-        VER().overwrite("?\0", 2) &&
-        IVER().overwrite("\12\0", 2) &&
-        IVE2().overwrite("\13\0", 2) &&
-        (MRGN().size() >= 5100 || MRGN().add<u8>(0, 5100 - MRGN().size()));
+    bool success = TYPE().overwrite("RAWS", 4);
+    success |= VER().overwrite("?\0", 2);
+    success |= IVER().overwrite("\12\0", 2);
+    success |= IVE2().overwrite("\13\0", 2);
+    success |= (MRGN().size() >= 5100 || MRGN().add<u8>(0, 5100 - MRGN().size()));
+    return success;
 }
 
 bool Scenario::ChangeToScExp()
 {
-    return TYPE().overwrite("RAWB", 4) &&
-        VER().overwrite("Í\0", 2) &&
-        RemoveSection(SectionId::IVER) &&
-        IVE2().overwrite("\13\0", 2) &&
-        (MRGN().size() >= 5100 || MRGN().add<u8>(0, 5100 - MRGN().size()));
+    bool success = TYPE().overwrite("RAWB", 4);
+    success |= VER().overwrite("Í\0", 2);
+    RemoveSection(SectionId::IVER);
+    success |= IVE2().overwrite("\13\0", 2);
+    success |= (MRGN().size() >= 5100 || MRGN().add<u8>(0, 5100 - MRGN().size()));
+    return success;
 }
 
 u16 Scenario::GetMapTitleStrIndex()

--- a/Chkdraft/src/NewMap.cpp
+++ b/Chkdraft/src/NewMap.cpp
@@ -45,7 +45,7 @@ BOOL NewMap::DlgCommand(HWND hWnd, WPARAM wParam, LPARAM lParam)
                     CM->Scroll(true, true, false);
 
                     // Tiling Code
-                    u16 tilenum = 0;
+                    /*u16 tilenum = 0;
                     u16 xSize = CM->XSize();
                     for ( u32 xStart = 0; xStart<CM->XSize(); xStart += 16 )
                     {
@@ -57,7 +57,7 @@ BOOL NewMap::DlgCommand(HWND hWnd, WPARAM wParam, LPARAM lParam)
                                 tilenum++;
                             }
                         }
-                    }
+                    }*/
 
                     CM->Redraw(true);
                 }

--- a/Chkdraft/src/TextTrigCompiler.cpp
+++ b/Chkdraft/src/TextTrigCompiler.cpp
@@ -3781,7 +3781,7 @@ s32 TextTrigCompiler::ExtendedNumConditionArgs(ConditionId conditionId)
     switch ( conditionId )
     {
         case ConditionId::Custom:
-            return 8;
+            return 9;
         case ConditionId::Memory:
             return 3;
     }

--- a/Chkdraft/src/WindowsUI/ClassWindow.cpp
+++ b/Chkdraft/src/WindowsUI/ClassWindow.cpp
@@ -228,6 +228,7 @@ LRESULT CALLBACK ClassWindow::ForwardWndProc(HWND hWnd, UINT msg, WPARAM wParam,
                 classWindow->NotifyWindowShown();
             else
             {
+                // When window is being hidden unfocus any focused edit boxes
                 HWND hEditFocused = GetFocus();
                 int editCtrlId = GetDlgCtrlID(hEditFocused);
                 classWindow->NotifyEditFocusLost(editCtrlId, hEditFocused);

--- a/Chkdraft/src/WindowsUI/ClassWindow.h
+++ b/Chkdraft/src/WindowsUI/ClassWindow.h
@@ -25,7 +25,7 @@ class ClassWindow : public WindowsItem
     protected:
 
 /*     Setup    */  /** Attempts to register a class for creating the window
-                        If the class has been registered before this returns false
+                        If the class has been registered before, this returns false
                         Do not register different classes with the same name */
                     bool RegisterWindowClass(UINT style, HICON hIcon, HCURSOR hCursor, HBRUSH hbrBackground,
                         LPCTSTR lpszMenuName, LPCTSTR lpszClassName, HICON hIconSm, bool isMDIChild);


### PR DESCRIPTION
Bug/Error fixes:
	- Fixed an issue where new maps/saving maps in a new saveType (e.g. original, hybrid, expansion) wouldn't correct the size of the location section (new hybrid/expansion maps would not load in StarCraft)
	- Fixed an issue with Custom condition parser leaving off the last argument
	- Fixed an issue where Chkdraft would crash on exit due to smart pointer invoking delete on a pointer to std::out