### PR TITLE
Sound fixes

### DIFF
--- a/src/chkdraft/ui/dialog_windows/map_settings/sound_editor.cpp
+++ b/src/chkdraft/ui/dialog_windows/map_settings/sound_editor.cpp
@@ -485,15 +485,17 @@ void SoundEditorWindow::MapSoundSelectionChanged()
     else
     {
         buttonDeleteSound.EnableThis();
-        LPARAM soundStringId = 0;
         if ( selectedSoundEntry >= 0 && selectedSoundEntry < soundEntries.size() )
         {
-            if ( !CM->stringIsSound(size_t(soundEntries[selectedSoundEntry].stringId)) )
-                buttonDeleteSound.DisableThis();
-
-            SoundStatus soundStatus = CM->getSoundStatus(size_t(soundStringId));
+            SoundStatus soundStatus = CM->getSoundStatus(size_t(soundEntries[selectedSoundEntry].stringId));
             if ( soundStatus == SoundStatus::PendingMatch || soundStatus == SoundStatus::CurrentMatch || soundStatus == SoundStatus::VirtualFile )
                 buttonExtractSound.EnableThis();
+            
+            if ( !CM->stringIsSound(size_t(soundEntries[selectedSoundEntry].stringId)) &&
+                soundStatus != SoundStatus::PendingMatch && soundStatus != SoundStatus::CurrentMatch )
+            {
+                buttonDeleteSound.DisableThis();
+            }
         }
         buttonPlaySound.EnableThis();
     }

--- a/src/mapping_core/map_file.cpp
+++ b/src/mapping_core/map_file.cpp
@@ -475,7 +475,8 @@ bool MapFile::removeSoundByStringId(size_t soundStringId, bool removeIfUsed)
     if ( soundStringId != Chk::StringId::UnusedSound )
     {
         auto soundString = Scenario::getString<RawString>(soundStringId, Chk::Scope::Game);
-        Scenario::deleteString(soundStringId);
+        Scenario::deleteSoundReferences(soundStringId);
+        Scenario::deleteString(soundStringId, Chk::Scope::Both, true);
         if ( soundString )
             result = MpqAssetManager::removeAsset(*soundString);
     }

--- a/src/mapping_core/scenario.h
+++ b/src/mapping_core/scenario.h
@@ -31,6 +31,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
         void remapStringIds(const std::map<u32, u32> & stringIdRemappings);
         void deleteLocation(size_t locationId);
         void deleteString(size_t stringId);
+        void deleteSoundReferences(size_t stringId);
     };
 
     struct EditTrigger : RareEdit::TrackedElement<Chk::Trigger, PATH(root->triggers[0])>
@@ -58,6 +59,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
         void remapStringIds(const std::map<u32, u32>& stringIdRemappings);
         void deleteLocation(size_t locationId);
         void deleteString(size_t stringId);
+        void deleteSoundReferences(size_t stringId);
 
         void alignConditionsTop();
         void alignActionsTop();
@@ -70,6 +72,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
         void toggleDisabled();
         void remapBriefingStringIds(const std::map<u32, u32> & stringIdRemappings);
         void deleteBriefingString(size_t stringId);
+        void deleteBriefingSoundReferences(size_t stringId);
     };
 
     struct EditBriefingTrigger : RareEdit::TrackedElement<Chk::Trigger, PATH(root->briefingTriggers[0])>
@@ -82,6 +85,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
 
         void remapBriefingStringIds(const std::map<u32, u32>& stringIdRemappings);
         void deleteBriefingString(size_t stringId);
+        void deleteBriefingSoundReferences(size_t stringId);
 
         void alignActionsTop();
     };
@@ -486,6 +490,7 @@ struct Scenario : RareEdit::Tracked<MapData, Scenario, DescriptorIndex>
     bool stringIsSound(size_t stringId) const;
     size_t getSoundStringId(size_t soundIndex) const;
     void setSoundStringId(size_t soundIndex, size_t soundStringId);
+    void deleteSoundReferences(size_t stringId);
 
     bool triggerSwitchUsed(size_t switchId) const;
     bool triggerLocationUsed(size_t locationId) const;


### PR DESCRIPTION
- Fix extract and delete sound buttons being disabled when they shouldn't be
- Fix delete sound not removing all the references to the sound
- Remove unused lambda
- Investigated PlaySound crash, won't fix until working on ogg/flac support as it seems to be a win32 library issue, best solved by replacing the sound library https://github.com/TheNitesWhoSay/Chkdraft/issues/297