### PR TITLE
2.09 - Fixes & Speedups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG d5b58a6 # release-2.6.0
+  GIT_TAG 1d66d35 # release-2.6.1
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG 1d66d35 # release-2.6.1
+  GIT_TAG 67de40e # release-2.6.2
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG d5b58a6 # release-2.6.0
+  GIT_TAG 1d66d35 # release-2.6.1
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG 1d66d35 # release-2.6.1
+  GIT_TAG 67de40e # release-2.6.2
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/chkdraft/CMakeLists.txt
+++ b/src/chkdraft/CMakeLists.txt
@@ -24,7 +24,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG d5b58a6 # release-2.6.0
+  GIT_TAG 1d66d35 # release-2.6.1
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/chkdraft/CMakeLists.txt
+++ b/src/chkdraft/CMakeLists.txt
@@ -24,7 +24,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG 1d66d35 # release-2.6.1
+  GIT_TAG 67de40e # release-2.6.2
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/chkdraft/common_files/version.h
+++ b/src/chkdraft/common_files/version.h
@@ -8,7 +8,7 @@ using u16 = uint16_t;
 constexpr u16 MajorVersionNumber = 2;
 
 // Minor version is a 2-digit base-10 number
-constexpr u16 MinorVersionNumber = 8;
+constexpr u16 MinorVersionNumber = 9;
 
 u16 GetDateShort(); // Returns 384*(year-2000) + 32*month + day based on the date compiled
 

--- a/src/chkdraft/ui/dialog_windows/map_settings/string_editor/string_editor.cpp
+++ b/src/chkdraft/ui/dialog_windows/map_settings/string_editor/string_editor.cpp
@@ -226,9 +226,9 @@ LRESULT StringEditorWindow::Command(HWND hWnd, WPARAM wParam, LPARAM lParam)
     case BN_CLICKED:
         if ( LOWORD(wParam) == Id::DELETE_STRING &&
             WinLib::GetYesNo("Forcefully deleting a string could cause problems, continue?", "Warning") == WinLib::PromptResult::Yes &&
-            CM != nullptr && currSelString != 0 && CM->stringStored(currSelString) )
+            CM != nullptr && currSelString != 0 && CM->stringStored(currSelString, (extended ? Chk::Scope::Editor : Chk::Scope::Game)) )
         {
-            CM->deleteString(currSelString, Chk::Scope::Both, false);
+            CM->deleteString(currSelString, (extended ? Chk::Scope::Editor : Chk::Scope::Game), false);
             CM->refreshScenario();
         }
         else if ( LOWORD(wParam) == Id::SAVE_TO && CM != nullptr )
@@ -362,13 +362,13 @@ void StringEditorWindow::addUseItem(std::string str, size_t amount)
 
 bool StringEditorWindow::updateString(u32 stringNum)
 {
-    auto existingStr = CM->getString<ChkdString>((size_t)stringNum);
+    auto existingStr = CM->getString<ChkdString>((size_t)stringNum, (extended ? Chk::Scope::Editor : Chk::Scope::Game));
     auto editStr = editString.GetWinText();
     if ( CM != nullptr && editStr && existingStr && existingStr->compare(*editStr) != 0 )
     {
         if ( auto editStr = editString.GetWinText() )
         {
-            CM->replaceString<ChkdString>((size_t)stringNum, *editStr);
+            CM->replaceString<ChkdString>((size_t)stringNum, *editStr, (this->extended ? Chk::Scope::Editor : Chk::Scope::Game));
             if ( CM->locationStringUsed(currSelString, Chk::Scope::EditorOverGame) )
                 chkd.mainPlot.leftBar.mainTree.locTree.RebuildLocationTree();
 

--- a/src/chkdraft/ui/dialog_windows/trig_editor/triggers.cpp
+++ b/src/chkdraft/ui/dialog_windows/trig_editor/triggers.cpp
@@ -165,6 +165,46 @@ void TriggersWindow::RefreshGroupList()
     listGroups.SetRedraw(true);
 }
 
+void TriggersWindow::RefreshTrigger(std::size_t trigIndex)
+{
+    int updatedListIndex = -1;
+    int selIndex = -1;
+    LPARAM itemTrigIndex = 0;
+    if ( listTriggers.GetCurSel(selIndex) && selIndex != -1 &&
+         listTriggers.GetItemData(selIndex, itemTrigIndex) && static_cast<std::size_t>(itemTrigIndex) == trigIndex )
+    {
+        updatedListIndex = selIndex;
+    }
+    else
+    {
+        int found = listTriggers.FindItem(trigIndex);
+        if ( found != -1 )
+            updatedListIndex = found;
+    }
+
+    if ( updatedListIndex != -1 )
+    {
+        this->SetRedraw(false);
+        UINT width = 0;
+        UINT height = 0;
+        if ( this->trigListDc )
+            GetTriggerDrawSize(this->trigListDc.value(), width, height, *CM, trigIndex, CM->getTrigger(trigIndex));
+        else
+        {
+            trigListDc.emplace(listTriggers.getHandle());
+            trigListDc->setDefaultFont();
+            GetTriggerDrawSize(this->trigListDc.value(), width, height, *CM, trigIndex, CM->getTrigger(trigIndex));
+            trigListDc = std::nullopt;
+        }
+        listTriggers.SetItemHeight(updatedListIndex, height);
+        listTriggers.SetTopIndex(updatedListIndex);
+        this->SetRedraw(true);
+        this->RedrawThis();
+    }
+    else
+        RefreshTrigList();
+}
+
 void TriggersWindow::DoSize()
 {
     RECT rcCli;

--- a/src/chkdraft/ui/dialog_windows/trig_editor/triggers.h
+++ b/src/chkdraft/ui/dialog_windows/trig_editor/triggers.h
@@ -19,6 +19,7 @@ class TriggersWindow : public WinLib::ClassWindow
         bool DestroyThis();
         void RefreshWindow(bool focus);
         void RefreshGroupList();
+        void RefreshTrigger(std::size_t trigIndex);
         void DoSize();
 
         void DeleteSelection();

--- a/src/chkdraft/ui/dialog_windows/trig_modify/trig_actions.cpp
+++ b/src/chkdraft/ui/dialog_windows/trig_modify/trig_actions.cpp
@@ -373,7 +373,7 @@ bool TrigActionsWindow::TransformAction(std::size_t triggerIndex, std::size_t ac
 void TrigActionsWindow::RefreshActionAreas()
 {
     RefreshWindow(trigIndex);
-    chkd.trigEditorWindow->triggersWindow.RefreshWindow(false);
+    chkd.trigEditorWindow->triggersWindow.RefreshTrigger(trigIndex);
 }
 
 void TrigActionsWindow::UpdateActionName(u8 actionNum, const std::string & newText, bool refreshImmediately)
@@ -1134,7 +1134,7 @@ void TrigActionsWindow::ButtonEditString()
             }
 
             if ( result > 0 )
-                chkd.trigEditorWindow->triggersWindow.RefreshWindow(false);
+                chkd.trigEditorWindow->triggersWindow.RefreshTrigger(trigIndex);
 
             SetFocus(gridActions.getHandle());
         }
@@ -1184,7 +1184,7 @@ void TrigActionsWindow::ButtonEditSound()
             }
 
             if ( result > 0 )
-                chkd.trigEditorWindow->triggersWindow.RefreshWindow(false);
+                chkd.trigEditorWindow->triggersWindow.RefreshTrigger(trigIndex);
 
             SetFocus(gridActions.getHandle());
         }

--- a/src/chkdraft/ui/dialog_windows/trig_modify/trig_conditions.cpp
+++ b/src/chkdraft/ui/dialog_windows/trig_modify/trig_conditions.cpp
@@ -305,7 +305,7 @@ bool TrigConditionsWindow::TransformCondition(std::size_t triggerIndex, std::siz
 void TrigConditionsWindow::RefreshConditionAreas()
 {
     RefreshWindow(trigIndex);
-    chkd.trigEditorWindow->triggersWindow.RefreshWindow(false);
+    chkd.trigEditorWindow->triggersWindow.RefreshTrigger(trigIndex);
 }
 
 void TrigConditionsWindow::UpdateConditionName(u8 conditionNum, const std::string & newText, bool refreshImmediately)

--- a/src/chkdraft/ui/main_windows/gui_map.cpp
+++ b/src/chkdraft/ui/main_windows/gui_map.cpp
@@ -4489,3 +4489,41 @@ void GuiMap::checkSelChangeFlags()
     if ( clearFogSelChanged() )
         this->tileFogSelectionsChanged();
 }
+
+void GuiMap::element_added(strings_path, std::size_t index)
+{
+    if ( read.strings[index].has_value() )
+        logger.info() << "String added: " << index << " : " << read.strings[index].value() << std::endl;
+}
+
+void GuiMap::element_removed(strings_path, std::size_t index)
+{
+    if ( read.strings[index].has_value() )
+        logger.info() << "String removed: " << index << " : " << read.strings[index].value() << std::endl;
+}
+
+void GuiMap::value_changed(string_elem_path route, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString)
+{
+    const std::size_t index = route.index<0>();
+    logger.info() << "String[" << index << "] updated from \""
+        << (oldString ? (*oldString) : "") << "\" to \"" << (newString ? (*newString) : "") << "\"\n";
+}
+
+void GuiMap::element_added(editor_strings_path, std::size_t index)
+{
+    if ( read.strings[index].has_value() )
+        logger.info() << "Editor string added: " << index << " : " << read.strings[index].value() << std::endl;
+}
+
+void GuiMap::element_removed(editor_strings_path, std::size_t index)
+{
+    if ( read.strings[index].has_value() )
+        logger.info() << "Editor string removed: " << index << " : " << read.strings[index].value() << std::endl;
+}
+
+void GuiMap::value_changed(editor_string_elem_path route, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString)
+{
+    const std::size_t index = route.index<0>();
+    logger.info() << "Editor string[" << index << "] updated from \""
+        << (oldString ? (*oldString) : "") << "\" to \"" << (newString ? (*newString) : "") << "\"\n";
+}

--- a/src/chkdraft/ui/main_windows/gui_map.cpp
+++ b/src/chkdraft/ui/main_windows/gui_map.cpp
@@ -4493,37 +4493,37 @@ void GuiMap::checkSelChangeFlags()
 void GuiMap::element_added(strings_path, std::size_t index)
 {
     if ( read.strings[index].has_value() )
-        logger.info() << "String added: " << index << " : " << read.strings[index].value() << std::endl;
+        ;//logger.info() << "String added: " << index << " : " << read.strings[index].value() << std::endl;
 }
 
 void GuiMap::element_removed(strings_path, std::size_t index)
 {
     if ( read.strings[index].has_value() )
-        logger.info() << "String removed: " << index << " : " << read.strings[index].value() << std::endl;
+        ;//logger.info() << "String removed: " << index << " : " << read.strings[index].value() << std::endl;
 }
 
 void GuiMap::value_changed(string_elem_path route, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString)
 {
     const std::size_t index = route.index<0>();
-    logger.info() << "String[" << index << "] updated from \""
-        << (oldString ? (*oldString) : "") << "\" to \"" << (newString ? (*newString) : "") << "\"\n";
+    //logger.info() << "String[" << index << "] updated from \""
+    //    << (oldString ? (*oldString) : "") << "\" to \"" << (newString ? (*newString) : "") << "\"\n";
 }
 
 void GuiMap::element_added(editor_strings_path, std::size_t index)
 {
     if ( read.strings[index].has_value() )
-        logger.info() << "Editor string added: " << index << " : " << read.strings[index].value() << std::endl;
+        ;//logger.info() << "Editor string added: " << index << " : " << read.strings[index].value() << std::endl;
 }
 
 void GuiMap::element_removed(editor_strings_path, std::size_t index)
 {
     if ( read.strings[index].has_value() )
-        logger.info() << "Editor string removed: " << index << " : " << read.strings[index].value() << std::endl;
+        ;//logger.info() << "Editor string removed: " << index << " : " << read.strings[index].value() << std::endl;
 }
 
 void GuiMap::value_changed(editor_string_elem_path route, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString)
 {
     const std::size_t index = route.index<0>();
-    logger.info() << "Editor string[" << index << "] updated from \""
-        << (oldString ? (*oldString) : "") << "\" to \"" << (newString ? (*newString) : "") << "\"\n";
+    //logger.info() << "Editor string[" << index << "] updated from \""
+    //    << (oldString ? (*oldString) : "") << "\" to \"" << (newString ? (*newString) : "") << "\"\n";
 }

--- a/src/chkdraft/ui/main_windows/gui_map.h
+++ b/src/chkdraft/ui/main_windows/gui_map.h
@@ -277,6 +277,13 @@ class GuiMap : public MapFile, public WinLib::ClassWindow, private Chk::IsomCach
                     void tileFogSelectionsChanged();
                     void checkSelChangeFlags();
 
+                    void element_added(strings_path, std::size_t index) override;
+                    void element_removed(strings_path, std::size_t index) override;
+                    void value_changed(string_elem_path, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString) override;
+                    void element_added(editor_strings_path, std::size_t index) override;
+                    void element_removed(editor_strings_path, std::size_t index) override;
+                    void value_changed(editor_string_elem_path, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString) override;
+
                     void after_action(std::size_t actionIndex) override;
 
 /* Private Data */  std::optional<Graphics> scGraphics {};

--- a/src/map_gfx_utils/CMakeLists.txt
+++ b/src/map_gfx_utils/CMakeLists.txt
@@ -64,7 +64,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG d5b58a6 # release-2.6.0
+  GIT_TAG 1d66d35 # release-2.6.1
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/map_gfx_utils/CMakeLists.txt
+++ b/src/map_gfx_utils/CMakeLists.txt
@@ -64,7 +64,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG 1d66d35 # release-2.6.1
+  GIT_TAG 67de40e # release-2.6.2
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/mapping_core/CMakeLists.txt
+++ b/src/mapping_core/CMakeLists.txt
@@ -32,7 +32,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG d5b58a6 # release-2.6.0
+  GIT_TAG 1d66d35 # release-2.6.1
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/mapping_core/CMakeLists.txt
+++ b/src/mapping_core/CMakeLists.txt
@@ -32,7 +32,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG 1d66d35 # release-2.6.1
+  GIT_TAG 67de40e # release-2.6.2
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/src/mapping_core/map_file.cpp
+++ b/src/mapping_core/map_file.cpp
@@ -289,7 +289,7 @@ bool MapFile::openMapFile(const std::string & filePath)
                     if ( auto chkData = MpqFile::getFile("staredit\\scenario.chk", false) )
                     {
                         std::stringstream chk(std::ios_base::in|std::ios_base::out|std::ios_base::binary);
-                        std::copy(chkData->begin(), chkData->end(), std::ostream_iterator<u8>(chk));
+                        chk.write((const char*)&chkData.value()[0], chkData->size());
                         if ( Scenario::parse(chk, true) )
                         {
                             auto finish = std::chrono::high_resolution_clock::now();

--- a/src/mapping_core/scenario.cpp
+++ b/src/mapping_core/scenario.cpp
@@ -1083,8 +1083,11 @@ bool Scenario::parse(std::istream & is, bool fromMpq)
     bool hasLegacyKstr = false;
 
     // First read contents of "is" to "chk", this will allow jumping backwards when reading chks with jump sections
-    std::stringstream chk(std::ios_base::binary|std::ios_base::in|std::ios_base::out);
-    chk << is.rdbuf();
+    std::stringstream chkCopy(std::ios_base::binary|std::ios_base::in|std::ios_base::out);
+    if ( !fromMpq ) // Input not from MPQ may be a filestream requiring a copy first, if it was from mpq it's already an appropriate sstream
+        chkCopy << is.rdbuf();
+
+    std::istream & chk = fromMpq ? is : chkCopy;
     if ( !is.good() && !is.eof() )
     {
         logger.error("Unexpected failure reading scenario contents!");

--- a/src/mapping_core/scenario.cpp
+++ b/src/mapping_core/scenario.cpp
@@ -7099,18 +7099,22 @@ std::vector<Chk::Trigger> Scenario::replaceTriggerRange(size_t beginIndex, size_
     }
     else if ( beginIndex < endIndex && endIndex <= read.triggers.size() )
     {
-        auto begin = read.triggers.begin()+beginIndex;
-        auto end = read.triggers.begin()+endIndex;
         std::vector<Chk::Trigger> replacedTriggers(read.triggers.begin()+beginIndex, read.triggers.begin()+endIndex);
-        std::vector<std::size_t> replacedIndexes(endIndex-beginIndex, 0);
-        std::iota(replacedIndexes.begin(), replacedIndexes.end(), beginIndex);
-        edit->triggers.set(replacedIndexes, triggers);
+        for ( std::size_t i=beginIndex; i<endIndex; ++i )
+            edit->triggers[i] = triggers[i-beginIndex];
+
+        if ( triggers.size() > endIndex-beginIndex ) // New triggers are inserted at the end of the range
+        {
+            std::vector<Chk::Trigger> expansion(triggers.begin()+(endIndex-beginIndex), triggers.end());
+            edit->triggers.insert(endIndex, expansion);
+        }
+
         fixTriggerExtensions();
         return replacedTriggers;
     }
     else
         throw std::out_of_range(std::string("Range [") + std::to_string(beginIndex) + ", " + std::to_string(endIndex) +
-            ") is invalid for trigger list of size: " + std::to_string(triggers.size()));
+            ") is invalid for trigger list of size: " + std::to_string(read.triggers.size()));
 }
 
 bool Scenario::hasTriggerExtension(size_t triggerIndex) const
@@ -7343,22 +7347,30 @@ void Scenario::moveBriefingTrigger(size_t briefingTriggerIndexFrom, size_t brief
 
 std::vector<Chk::Trigger> Scenario::replaceBriefingTriggerRange(size_t beginIndex, size_t endIndex, std::vector<Chk::Trigger> & briefingTriggers)
 {
+    auto edit = create_action(ActionDescriptor::ReplaceBriefingTriggerRange);
     if ( beginIndex == 0 && endIndex == read.briefingTriggers.size() )
     {
         auto replacedBriefingTriggers = read.briefingTriggers;
-        create_action(ActionDescriptor::ReplaceBriefingTriggerRange)->briefingTriggers = briefingTriggers;
+        edit->briefingTriggers = briefingTriggers;
         return replacedBriefingTriggers;
     }
     else if ( beginIndex < endIndex && endIndex <= read.briefingTriggers.size() )
     {
         std::vector<Chk::Trigger> replacedBriefingTriggers(read.briefingTriggers.begin()+beginIndex, read.briefingTriggers.begin()+endIndex);
-        std::vector<std::size_t> replacedIndexes(endIndex-beginIndex);
-        std::iota(replacedIndexes.begin(), replacedIndexes.end(), beginIndex);
+        for ( std::size_t i=beginIndex; i<endIndex; ++i )
+            edit->briefingTriggers[i] = briefingTriggers[i-beginIndex];
+
+        if ( briefingTriggers.size() > endIndex-beginIndex ) // New briefing triggers are inserted at the end of the range
+        {
+            std::vector<Chk::Trigger> expansion(briefingTriggers.begin()+(endIndex-beginIndex), briefingTriggers.end());
+            edit->briefingTriggers.insert(endIndex, expansion);
+        }
+
         return replacedBriefingTriggers;
     }
     else
         throw std::out_of_range(std::string("Range [") + std::to_string(beginIndex) + ", " + std::to_string(endIndex) +
-            ") is invalid for briefing trigger list of size: " + std::to_string(briefingTriggers.size()));
+            ") is invalid for briefing trigger list of size: " + std::to_string(read.briefingTriggers.size()));
 }
 
 size_t Scenario::addSound(size_t stringId)

--- a/src/mapping_core/scenario.h
+++ b/src/mapping_core/scenario.h
@@ -583,6 +583,18 @@ struct Scenario : nf::tracked<MapData, Scenario, DescriptorIndex>
     void selections_changed(tiles_path);
     void selections_changed(editor_tiles_path);
     void selections_changed(tiles_fog_path);
+
+    using strings_path = NF_PATH(root->strings);
+    using string_elem_path = NF_PATH(root->strings[0]);
+    using editor_strings_path = NF_PATH(root->editorStrings);
+    using editor_string_elem_path = NF_PATH(root->editorStrings[0]);
+    virtual void element_added(strings_path, std::size_t index) {}
+    virtual void element_removed(strings_path, std::size_t index) {}
+    virtual void value_changed(string_elem_path, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString) {}
+    virtual void element_added(editor_strings_path, std::size_t index) {}
+    virtual void element_removed(editor_strings_path, std::size_t index) {}
+    virtual void value_changed(editor_string_elem_path, const std::optional<ScStr> & oldString, const std::optional<ScStr> & newString) {}
+
     virtual void after_action(std::size_t actionIndex) {} // Does nothing unless overridden
 
 

--- a/src/windows/list_box_control.cpp
+++ b/src/windows/list_box_control.cpp
@@ -293,6 +293,12 @@ namespace WinLib {
     {
         return (int)SendMessage(getHandle(), LB_GETTOPINDEX, 0, 0);
     }
+    
+    int ListBoxControl::FindItem(LPARAM itemData)
+    {
+        DWORD result = SendMessage(getHandle(), LB_FINDSTRING, -1, itemData);
+        return result == LB_ERR ? -1 : static_cast<int>(result);
+    }
 
     LRESULT ListBoxControl::ControlProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
     {

--- a/src/windows/list_box_control.h
+++ b/src/windows/list_box_control.h
@@ -41,6 +41,7 @@ namespace WinLib {
             bool GetSelItem(int n, LPARAM & itemData); // Attempts to get the nth selected item's data (in a multi-selection list box)
             bool GetItemData(int index, LPARAM & data);
             int GetTopIndex();
+            int FindItem(LPARAM itemData);
 
         protected:
             virtual LRESULT ControlProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/test/mapping_core/CMakeLists.txt
+++ b/test/mapping_core/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG d5b58a6 # release-2.6.0
+  GIT_TAG 1d66d35 # release-2.6.1
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)

--- a/test/mapping_core/CMakeLists.txt
+++ b/test/mapping_core/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 FetchContent_Declare(
   rarecpp
   GIT_REPOSITORY https://github.com/TheNitesWhoSay/RareCpp.git
-  GIT_TAG 1d66d35 # release-2.6.1
+  GIT_TAG 67de40e # release-2.6.2
 )
 FetchContent_MakeAvailable(rarecpp)
 include_directories(${rarecpp_SOURCE_DIR}/include)


### PR DESCRIPTION
- Fix a crash that occurred when compiling text for an individual trigger from the trigger gui
- Fixes a bug where the string editor edited game strings when it should edit editor strings
- Improve triggering performance for maps with large trigger quantities
- Makes large scenario file reads 3-5 times faster