### PR TITLE
Bugfix/map render

### DIFF
--- a/src/mapping_core/map_file.cpp
+++ b/src/mapping_core/map_file.cpp
@@ -286,21 +286,22 @@ bool MapFile::openMapFile(const std::string & filePath)
 
                 auto tryGetScenario = [&]() -> std::optional<std::string> {
                     try {
-                    if ( auto chkData = MpqFile::getFile("staredit\\scenario.chk", false) )
-                    {
-                        std::stringstream chk(std::ios_base::in|std::ios_base::out|std::ios_base::binary);
-                        chk.write((const char*)&chkData.value()[0], chkData->size());
-                        if ( Scenario::parse(chk, true) )
+                        if ( auto chkData = MpqFile::getFile("staredit\\scenario.chk", false) )
                         {
-                            auto finish = std::chrono::high_resolution_clock::now();
-                            logger.info() << "Map " << mapFilePath << " opened in " << std::chrono::duration_cast<std::chrono::milliseconds>(finish-start).count() << "ms" << std::endl;
-                            return std::nullopt; // No error
+                            std::stringstream chk(std::ios_base::in|std::ios_base::out|std::ios_base::binary);
+                            chk.write((const char*)&chkData.value()[0], chkData->size());
+                            if ( Scenario::parse(chk, true) )
+                            {
+                                auto finish = std::chrono::high_resolution_clock::now();
+                                logger.info() << "Map " << mapFilePath << " opened in "
+                                    << std::chrono::duration_cast<std::chrono::milliseconds>(finish-start).count() << "ms" << std::endl;
+                                return std::nullopt; // No error
+                            }
+                            else
+                                return std::make_optional(std::string("Invalid or missing Scenario file."));
                         }
                         else
                             return std::make_optional(std::string("Invalid or missing Scenario file."));
-                    }
-                    else
-                        return std::make_optional(std::string("Invalid or missing Scenario file."));
                     } catch ( std::exception & e ) {
                         return std::make_optional(std::string("Exception occurred while parsing scenario ") + e.what());
                     } catch ( ... ) {
@@ -317,12 +318,15 @@ bool MapFile::openMapFile(const std::string & filePath)
                     auto locales = MpqFile::getLocales("staredit\\scenario.chk");
                     for ( auto locale : locales )
                     {
-                        MpqFile::setLocale(locale);
-                        if ( tryGetScenario() == std::nullopt ) // No error to report
+                        if ( locale != prevLocale )
                         {
-                            MpqFile::setLocale(prevLocale); // Restore original locale
-                            Scenario::setProtected();
-                            return true;
+                            MpqFile::setLocale(locale);
+                            if ( tryGetScenario() == std::nullopt ) // No error to report
+                            {
+                                MpqFile::setLocale(prevLocale); // Restore original locale
+                                Scenario::setProtected();
+                                return true;
+                            }
                         }
                     }
                     MpqFile::setLocale(prevLocale); // Restore original locale

--- a/src/mapping_core/scenario.cpp
+++ b/src/mapping_core/scenario.cpp
@@ -1119,8 +1119,14 @@ bool Scenario::parse(std::istream & is, bool fromMpq)
 
                 if ( chk.good() || chk.eof() )
                 {
-                    if ( Chk::SectionSize(chk.tellg() - begin) != sectionHeader.sizeInBytes ) // Undersized section
+                    auto sizeRead = Chk::SectionSize(chk.tellg() - begin);
+                    if ( sizeRead < sectionHeader.sizeInBytes && !chk.eof() ) // Read less than the section size
+                    {
                         makeProtected = true;
+                        chk.seekg(sectionHeader.sizeInBytes - sizeRead, std::ios_base::cur); // Seek to the end of the section
+                    }
+                    else if ( sizeRead > sectionHeader.sizeInBytes )
+                        return parsingFailed("Parser code issue: read past the end of a chk section");
                 }
                 else
                     return parsingFailed("Unexpected error reading chk section contents!");


### PR DESCRIPTION
- Fix an issue where the map stream was not always advanced past the full section size
- Add an error if the parser reads more than the section size for a given chk section
- Fix an issue where the default locale was re-attempted (as part of the locale list) when parsing of said locale already failed